### PR TITLE
Add lift area to Part

### DIFF
--- a/app/controllers/parts_controller.rb
+++ b/app/controllers/parts_controller.rb
@@ -32,6 +32,7 @@ class PartsController < AuthenticatedController
     @part = Part.where(name: options['name']).first_or_create
     @part.cost = options['cost'].to_f rescue 0
     @part.mass = options['mass'].to_f rescue 0
+    @part.lift_area = options['deflectionLiftCoeff'].to_f rescue 0
     @part.save
 
     respond_to do |format|

--- a/app/models/part.rb
+++ b/app/models/part.rb
@@ -3,6 +3,7 @@ class Part < ApplicationRecord
   validates :cost, presence: true, numericality: true
   validates :mass, presence: true, numericality: true
   validates :points, presence: true, numericality: true
+  validates :lift_area, presence: true, numericality: true
 
   before_validation :assign_defaults
 
@@ -10,5 +11,6 @@ class Part < ApplicationRecord
     self.cost = 0 if cost.nil?
     self.mass = 0 if mass.nil?
     self.points = 0 if points.nil?
+    self.lift_area = 0 if lift_area.nil?
   end
 end

--- a/db/migrate/20230107172349_add_lift_area_to_parts.rb
+++ b/db/migrate/20230107172349_add_lift_area_to_parts.rb
@@ -1,0 +1,6 @@
+class AddLiftAreaToParts < ActiveRecord::Migration[6.0]
+  def change
+    add_column :parts, :lift_area, :float
+    Part.update_all(lift_area: 0)
+  end
+end

--- a/lib/part_library.rb
+++ b/lib/part_library.rb
@@ -1,23 +1,25 @@
 module PartLibrary
   class KspPart
     def self.interpret(file)
-      valid_keys = [:name, :cost, :mass]
+      valid_keys = [:name, :cost, :mass, :deflectionLiftCoeff]
       props = {}
       body = file.tempfile.read
       lines = body.lines
       line_count = lines.count
       midx = lines.index { |e| e =~ /MODULE/ } || line_count
       ridx = lines.index { |e| e =~ /RESOURCE/ } || line_count
-      eidx = [midx, ridx].min
-      part_lines = lines[0..eidx]
-      part_lines.each do |e|
-        # puts "in: #{e}"
+      # eidx = [midx, ridx].min
+      # part_lines = lines[0..eidx]
+      # part_lines.each do |e|
+      lines.each do |e|
+        puts "in: #{e}"
         next if e =~ /\/\//
         results = /\s*(.+) = (.+)$/.match(e)
         next if results.nil?
         if valid_keys.include?(results[1].to_sym)
-          # puts "found: '#{results[1]}' = '#{results[2]}'"
+          puts "found: '#{results[1]}' = '#{results[2]}'"
           props[results[1]] = results[2].strip
+          valid_keys.delete(results[1].to_sym)
         end
       end
       return props


### PR DESCRIPTION
In order to include things like wing loading in the craft evaluator report, the api needs to know about the lifting area defined in the part file (if any). This change extracts lift metadata from uploaded part files and stores it in a new column in the parts table.